### PR TITLE
Remove duplicate rendering

### DIFF
--- a/src/Pdf/View.php
+++ b/src/Pdf/View.php
@@ -96,9 +96,6 @@ class View implements Renderable, Responsable
             return $this->toDebugResponse();
         }
 
-        $html = $this->view->render();
-        $result = $this->pdf->render($html);
-
         $cb = function () {
             echo $this->render();
         };


### PR DESCRIPTION
Removed uneccesary duplicate rendering in toResponse().

The result of the first render was stored in $result and then never used.

Only the second render via $this->render() was actually returned in the response.