### PR TITLE
Resolve per-request reconstruction of typesetsh singletons under Octane

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -65,6 +65,11 @@ class ServiceProvider extends Support\ServiceProvider implements Contracts\Suppo
 
             return new Pdf\Factory($app['typesetsh'], $app['view'], $debug);
         });
+
+        // Allow resolving the singletons via class-name injection; without the
+        // aliases (+ provides() below) a type-hint autowires a fresh instance.
+        $this->app->alias('typesetsh', Typesetsh::class);
+        $this->app->alias('typesetsh.pdf', Pdf\Factory::class);
     }
 
     /**
@@ -74,6 +79,6 @@ class ServiceProvider extends Support\ServiceProvider implements Contracts\Suppo
      */
     public function provides(): array
     {
-        return ['typesetsh', 'typesetsh.pdf'];
+        return ['typesetsh', Typesetsh::class, 'typesetsh.pdf', Pdf\Factory::class];
     }
 }


### PR DESCRIPTION
A small but high-impact fix for long-running workers (we hit it on FrankenPHP/Octane).

The singletons are only bound under the string keys `typesetsh` / `typesetsh.pdf`. Injecting `Typesetsh\LaravelWrapper\Typesetsh` by type-hint — the usual way — doesn't get the singleton: the provider is deferred and `provides()` lists only the string keys, so resolving the class-name boots no provider and matches no binding, and the container reflection-builds a fresh `Typesetsh` (and the whole `HtmlToPdf` graph) on every resolution. Under FrankenPHP that rebuilds ~MB per request and eventually exhausts memory — even on requests that render no PDF but merely autowire something depending on `Typesetsh`. Fix: alias the class-names to the singleton keys and add them to `provides()` so the class-name is a deferred trigger. After it, `app(Typesetsh::class) === app('typesetsh')`.

Quick check:

```
php artisan tinker --execute="var_dump(app('typesetsh') === app(\Typesetsh\LaravelWrapper\Typesetsh::class));"
// before: false   after: true
```

Based off `laravel-7` as it looked like the active branch — happy to retarget.
