### PR TITLE
Allow Laravel 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <p align="center"><img src="https://static.typeset.sh/images/typeset.sh-logo.svg" width="300"></p>
 
 
-# Typeset.sh wrapper for Laravel 7, 8, 9, 10, 11 and 12
+# Typeset.sh wrapper for Laravel 7, 8, 9, 10, 11, 12 and 13
 
 This is a laravel typeset.sh wrapper that lets you easily configure and use typeset.sh
 in your laravel project. Typeset.sh is a printcss layout and rendering engine written in PHP.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "typesetsh/laravel-wrapper",
-    "description": "Typeset.sh wrapper for laravel 7-12",
+    "description": "Typeset.sh wrapper for laravel 7-13",
     "type": "library",
     "license": "MIT",
     "authors": [
@@ -15,7 +15,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "laravel/framework": "^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
+        "laravel/framework": "^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
         "typesetsh/typesetsh": "^0.27.0"
     },
     "require-dev": {


### PR DESCRIPTION
Widens the `laravel/framework` constraint to include `^13.0` (and bumps the description's version range). The wrapper only touches the container, config and views — nothing removed in 13 — and the rendering engine packages carry no Laravel dependency, so the constraint is the only thing gating 13. Based off `laravel-7`; let me know if you'd rather it target a different branch.
